### PR TITLE
Use EMC_ROOT to update the path to avoid validity period issue

### DIFF
--- a/pyemc/runner.py
+++ b/pyemc/runner.py
@@ -35,7 +35,10 @@ def _get_path() -> str:
     Returns:
         module_path (str): the path of the module
     '''
-    return os.path.dirname(__file__)
+
+    # If a newer version of EMC has been downloaded,
+    # the EMC_ROOT environment variable needs to be set to use that.
+    return os.environ.get('EMC_ROOT', os.path.dirname(__file__))
 
 
 def setup(esh_file: str, *args):
@@ -47,8 +50,15 @@ def setup(esh_file: str, *args):
     Returns:
         None
     '''
-    emc_setup_file = os.path.join(_get_path(), 'emc', 'scripts',
+
+    # If EMC_ROOT was defined
+    emc_setup_file = os.path.join(_get_path(), 'scripts',
                                   'emc_setup.pl')
+
+    # Used the packaged version
+    if not os.path.isfile(emc_setup_file):
+        emc_setup_file = os.path.join(_get_path(), 'emc', 'scripts',
+                                    'emc_setup.pl')
 
     command = ['perl', str(emc_setup_file), esh_file]
     for arg in args:
@@ -65,6 +75,12 @@ def build(build_file: str):
     Returns:
         None
     '''
-    emc_bin_file = os.path.join(_get_path(), 'emc', 'bin', _get_exec())
+
+    # If EMC_ROOT was defined
+    emc_bin_file = os.path.join(_get_path(), 'bin', _get_exec())
+    
+    # Used the packaged version
+    if not os.path.isfile(emc_bin_file):
+        emc_bin_file = os.path.join(_get_path(), 'emc', 'bin', _get_exec())
 
     subprocess.run([str(emc_bin_file), build_file])


### PR DESCRIPTION
This commit will check if the `EMC_ROOT` environment variable is defined, and adjust the paths to the EMC bin file and Perl script accordingly. This will allow the user to download a newer version of EMC and set the `EMC_ROOT` environment variable to the extracted package directory. If `EMC_ROOT` is not defined, the program will fall back to the packaged EMC version (inside the `emc/` directory).